### PR TITLE
✨ feat(downloader): support original quality (bestvideo+bestaudio) an…

### DIFF
--- a/plugins/stash-downloader/scripts/download.py
+++ b/plugins/stash-downloader/scripts/download.py
@@ -717,7 +717,7 @@ def download_video(
         url: Video URL to download
         output_dir: Directory to save the video
         filename_template: yt-dlp output template
-        quality: Quality preference (best, 1080p, 720p, 480p)
+        quality: Quality preference (best, original, 1080p, 720p, 480p, "CUSTOM_YT-DLP_QUALITY")
         progress_callback: Optional callback for progress updates
         proxy: Optional HTTP/HTTPS/SOCKS proxy (e.g., http://proxy.example.com:8080)
         progress_id: Optional ID for progress file updates (for frontend polling)
@@ -731,12 +731,19 @@ def download_video(
 
     # Build format string based on quality preference
     format_str = "bestvideo[ext=mp4]+bestaudio[ext=m4a]/best[ext=mp4]/best"
-    if quality == "1080p":
+    if quality == "original":
+        format_str = "bestvideo+bestaudio/best"
+    elif quality == "best":
+        # this has to be pass so that "best" doesn't just go into "else"
+        pass
+    elif quality == "1080p":
         format_str = "bestvideo[height<=1080][ext=mp4]+bestaudio[ext=m4a]/best[height<=1080][ext=mp4]/best"
     elif quality == "720p":
         format_str = "bestvideo[height<=720][ext=mp4]+bestaudio[ext=m4a]/best[height<=720][ext=mp4]/best"
     elif quality == "480p":
         format_str = "bestvideo[height<=480][ext=mp4]+bestaudio[ext=m4a]/best[height<=480][ext=mp4]/best"
+    else:
+        format_str = quality
 
     output_template = os.path.join(output_dir, filename_template)
 

--- a/plugins/stash-downloader/stash-downloader.yml
+++ b/plugins/stash-downloader/stash-downloader.yml
@@ -33,7 +33,7 @@ settings:
     type: BOOLEAN
   downloadQuality:
     displayName: Download Quality
-    description: "Preferred quality for video downloads (best, 1080p, 720p, 480p)"
+    description: "Preferred quality for video downloads (best, original, 1080p, 720p, 480p, \"CUSTOM_YT-DLP_QUALITY\")"
     type: STRING
   filenameTemplate:
     displayName: Filename Template


### PR DESCRIPTION
## Summary

Hi, thanks for this project! I noticed that Stash-Downloader prefers mp4 when many websites prefer other more modern formats. This PR just adds non-breaking opt-in feature where yt-dlp tries to download the actual best quality (titled "original") offered by a website. It also adds ability to add custom quality string, which could break user experience only if users set quality to a nonsensical value in the first place.

## Changes

Adds the actual best quality from yt-dlp but it's labelled "original" so that defaults are preserved and it doesn't surprise users after updating. Also adds support for custom quality formats.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)

## Testing

Tested quality using [this YT video](https://www.youtube.com/watch?v=flkK-bnq9nA) and these 3 configurations:

1. custom -> "bestvideo[vcodec^=avc1][height<=1080]+bestaudio[ext=m4a]/best[ext=mp4]"
2. "best"
3. "original"

I can't get consistent results across different videos because YouTube keeps pushing modern formats if it detects that you can accept them. Though, the usual is this:
**1. Custom: works!**
**2. Bigger size: H.264 (2003) - older codec** (difficult to test)
**3. Smaller size: AV1 (2018) - modern codec**

- [x] Tested locally in Stash
- [x] Tested with Docker
- [ ] Added/updated tests
- [ ] Tested browser extension (if applicable)

## Checklist

- [x] My code follows the project's code style
- [x] I have performed a self-review of my code
- [x] I have commented my code where necessary
- [ ] I have updated documentation if needed
- [ ] My changes generate no new warnings
- [ ] Tests pass locally (`npm test`)
- [ ] Build succeeds (`npm run build`)

## Related Issues

N/A

## Screenshots

N/A
